### PR TITLE
Stupid ass visual studio forced renaming shit

### DIFF
--- a/include/geometrycentral/surface/meshio.h
+++ b/include/geometrycentral/surface/meshio.h
@@ -40,7 +40,7 @@ loadMesh(std::string filename, std::string type = "");
 
 // Load mesh data from arbitrary source providing raw geometry information
 std::tuple<std::unique_ptr<ManifoldSurfaceMesh>, std::unique_ptr<VertexPositionGeometry>>
-loadMesh(std::vector<std::vector<size_t>>& polygons, std::vector<Vector3>& vertexCoordinates);
+loadMeshFromExplicitGeometry(std::vector<std::vector<size_t>>& polygons, std::vector<Vector3>& vertexCoordinates);
 
 
 // Write a surface mesh

--- a/src/surface/meshio.cpp
+++ b/src/surface/meshio.cpp
@@ -62,7 +62,7 @@ std::tuple<std::unique_ptr<ManifoldSurfaceMesh>, std::unique_ptr<VertexPositionG
 }
 
 std::tuple<std::unique_ptr<ManifoldSurfaceMesh>, std::unique_ptr<VertexPositionGeometry>>
-loadMesh(std::vector<std::vector<size_t>>& polygons, std::vector<Vector3>& vertexCoordinates) {
+loadMeshFromExplicitGeometry(std::vector<std::vector<size_t>>& polygons, std::vector<Vector3>& vertexCoordinates) {
   std::string loadType = "custom";
   std::cout << "Declaring polygon mesh" << std::endl;
   SimplePolygonMesh simpleMesh(polygons, vertexCoordinates);


### PR DESCRIPTION
Because Visual Studio on Windows is too retarded to template type match and things longs and strings are indistinguishable.